### PR TITLE
remove hard *ecto_migrate* dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,6 @@ defmodule EctoTtl.Mixfile do
      {:mariaex, ">= 0.0.0", optional: true},
      {:ecto, ">= 0.13.0"},
      {:ecto_it, ">= 0.1.0", optional: true},
-     {:ecto_migrate, ">= 0.4.0"}]
+     {:ecto_migrate, ">= 0.4.0", optional: true}]
   end
 end


### PR DESCRIPTION
this commit removes the hard requirement for *ecto_migrate*. the job of
*ecto_ttl* is to only take care of the "time to live" extensions of given
models. enforcing a certain style of migrations (eg, automatic migrations) is
not it's job.